### PR TITLE
fix buffer boundary check

### DIFF
--- a/statsd_test.go
+++ b/statsd_test.go
@@ -206,3 +206,47 @@ func TestMultiPacketOverflow(t *testing.T) {
 	c.Flush()
 	assert(t, buf.String(), "unique:765|s")
 }
+
+func TestMultiPacketOverflowNewline(t *testing.T) {
+	buf := new(bytes.Buffer)
+	c := &Client{
+		buf: bufio.NewWriterSize(buf, 24),
+	}
+
+	//write to the buffer, sized at 12
+	err := c.Unique("unique", 765, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	//make sure this write accounts for the newline
+	err = c.Unique("unique", 766, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert(t, buf.String(), "unique:765|s")
+	buf.Reset()
+	c.Flush()
+	assert(t, buf.String(), "unique:766|s")
+}
+
+func TestMultiPacketExact(t *testing.T) {
+	buf := new(bytes.Buffer)
+	c := &Client{
+		buf: bufio.NewWriterSize(buf, 25),
+	}
+
+	//write to the buffer, sized at 12
+	err := c.Unique("unique", 765, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = c.Unique("unique", 766, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert(t, buf.String(), "")
+	c.Flush()
+	assert(t, buf.String(), "unique:765|s\nunique:766|s")
+}


### PR DESCRIPTION
I believe there are possible issues when evaluating the needed buffer capacity.
- situation where buffer already has content, and the stat to be written fits exactly in the remaining buffer capacity. The boundary check should account for the prepend  newline.
- situation where formatting is done during write using `fmt.Fpringf(...)` leads to inaccurate length check of the data to be written.